### PR TITLE
PR for updating WhatsApp share buttons to include their new click-to-chat format

### DIFF
--- a/system/modules/sharebuttons/templates/sharebuttons_default.html5
+++ b/system/modules/sharebuttons/templates/sharebuttons_default.html5
@@ -20,8 +20,8 @@
       <?php endif ;?>
       <?php if ($network == 'reddit'): ?>
         <li><a class="reddit" href="http://www.reddit.com/submit?url=<?= $this->url ?>&amp;title=<?= $this->title ?>" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['share_on_reddit'] ?>" onclick="return shd.open(this.href,855,900);">Reddit</a></li>
-      <?php elseif ($network == 'whatsapp' && \Environment::get('agent')->mobile): ?>
-        <li><a class="whatsapp" href="whatsapp://send?text=<?= $this->description ? $this->description . '%0A%0A' : '' ?><?= $this->url ?>" data-action="share/whatsapp/share" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['share_on_whatsapp'] ?>">WhatsApp</a></li>
+      <?php elseif ($network == 'whatsapp'): ?>
+        <li><a class="whatsapp" href="https://wa.me/?text=<?= $this->description ? $this->description . '%0A%0A' : '' ?><?= $this->url ?>" target="_blank" data-action="share/whatsapp/share" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['share_on_whatsapp'] ?>">WhatsApp</a></li>
       <?php elseif ($network == 'print'): ?>
         <li><a class="print" href="#" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['print_page'] ?>" onclick="window.print();return false"><?= $this->lang['print_page'] ?></a></li>
       <?php elseif ($network == 'pdf' && $this->pdfLink): ?>

--- a/system/modules/sharebuttons/templates/sharebuttons_fontawesome.html5
+++ b/system/modules/sharebuttons/templates/sharebuttons_fontawesome.html5
@@ -20,8 +20,8 @@
       <?php endif ;?>
       <?php if ($network == 'reddit'): ?>
         <li><a class="reddit fa fa-reddit" href="http://www.reddit.com/submit?url=<?= $this->url ?>&amp;title=<?= $this->title ?>" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['share_on_reddit'] ?>" onclick="return shd.open(this.href,855,900);"></a></li>
-      <?php elseif ($network == 'whatsapp' && \Environment::get('agent')->mobile): ?>
-        <li><a class="whatsapp fa fa-whatsapp" href="whatsapp://send?text=<?= $this->description ? $this->description . '%0A%0A' : '' ?><?= $this->url ?>" data-action="share/whatsapp/share" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['share_on_whatsapp'] ?>"></a></li>
+      <?php elseif ($network == 'whatsapp'): ?>
+        <li><a class="whatsapp fa fa-whatsapp" href="https://wa.me/?text=<?= $this->description ? $this->description . '%0A%0A' : '' ?><?= $this->url ?>" target="_blank" data-action="share/whatsapp/share" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['share_on_whatsapp'] ?>"></a></li>
       <?php elseif ($network == 'print'): ?>
         <li><a class="print fa fa-print" href="#" rel="noopener noreferrer nofollow" data-escargot-ignore title="<?= $this->lang['print_page'] ?>" onclick="window.print();return false"></a></li>
       <?php elseif ($network == 'pdf' && $this->pdfLink): ?>


### PR DESCRIPTION
Hello @fritzmg,

this PR introduces the new whatsapp click to chat function. They did change the way they are sharing messages a while ago and it works with desktop clients as well.
It should fix Issue https://github.com/fritzmg/contao-sharebuttons/issues/37.

### Changes: ###
I removed the \Environment check completely. We won't need it with whatsapp-web being on desktop clients and the \Environment class didn't get mobile devices anymore.

I've debugged through my local installation and found out that it even used the Environment class from certain tests from other plugins such as Haste. It should have been used with Contao\Environment to not introduce other bugs. I do think it isn't needed anymore.

I've also added a target _blank so users do not leave the website when clicking on the link (Important for desktop clients).

### References: ###
https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat